### PR TITLE
add esp-mqtt-arduino into repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8424,3 +8424,4 @@ https://github.com/WeSpeakEnglish/ANTIRTOS_MODERN
 https://github.com/hidori/MicroSerial
 https://github.com/7semi-solutions/7Semi-BNO055-Arduino-Library
 https://github.com/ConsentiumIoT/EdgeVision
+https://github.com/junzzhu/esp-mqtt-arduino


### PR DESCRIPTION
# esp-mqtt-arduino

Arduino wrapper around Espressif's official [esp-mqtt](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/protocols/mqtt.html) client, enabling **MQTT v5.0** features in Arduino IDE for ESP32.

## Features
- MQTT 5.0 on ESP32